### PR TITLE
[Modify] self-hosted runner적용으로 변경

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on: # 아래 job을 실행시킬 상황
 jobs: # 작동할 일
   deploy:
     name: deploy #github 아이콘에 나타날 과정 이름
-    runs-on: ubuntu-latest # 실행될 인스턴스 OS와 버전
+    runs-on: self-hosted # GitHub Actions의 일부로 사용자 정의된 머신으로 self-hosted runner라 불림
 
     steps:
       - name: excuting remote ssh commands # 각 단계 이름


### PR DESCRIPTION
- ec2 인스턴스의 security-group의 인바운드 규칙으로 인해 아무 IP에서나 접근 불가능함
- 자체 서버에 self-hosted runner를 등록하고, GitHub Actions에서 작업을 실행할 때 해당 runner를 대상으로 지정할 수 있게 도와줌. 이렇게 하면 소스 코드와 작업 데이터가 사용자가 소유한 환경에서 안전하게 유지될 수 있으며, 실행 시간과 자원에 대한 더 많은 제어권을 가질 수 있다고 한다..
  - [Hosting your own runners
](https://docs.github.com/en/actions/hosting-your-own-runners)