### PR TITLE
Fix pagination issue for last page

### DIFF
--- a/routes/post-list.js
+++ b/routes/post-list.js
@@ -86,13 +86,9 @@ postList.get("/post-list", (req, res) => {
 
   //*todo: 리팩토링 필요
   const totalCount = posts.length;
-  const pageCondition = countPerPage * pageNo > totalCount;
-  const start = pageCondition
-    ? (pageNo - 2) * countPerPage
-    : (pageNo - 1) * countPerPage;
-  const end = pageCondition ? totalCount : countPerPage * pageNo;
+  const totalPageCount = Math.ceil(totalCount / countPerPage);
 
-  if (pageCondition) {
+  if (pageNo < 1 || pageNo > totalPageCount) {
     return res.json({
       success: false,
       message: "page out of range",
@@ -103,6 +99,9 @@ postList.get("/post-list", (req, res) => {
       },
     });
   }
+
+  const start = (pageNo - 1) * countPerPage;
+  const end = Math.min(start + countPerPage, totalCount);
 
   if (pageNo > 0) {
     return res.json({


### PR DESCRIPTION
## Summary
- handle pagination edge case where last page was reported as out of range
- adjust start/end calculations using total page count

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6886ba7abf088320bdf06f5ad5f78774