### PR TITLE
Add SOCAR resume entries: raffleBackoffice, couponWebview, bundlingProject and wire into EXPERIENCE list

### DIFF
--- a/src/languages/eng/Resume/experience.js
+++ b/src/languages/eng/Resume/experience.js
@@ -28,7 +28,26 @@ export const SOCAR = {
     design: "Synchronize design language and development language as much as possible with meaningful tokens",
     structure: "Designed with Pulling and Pushing systems in mind",
     component: "Designed as a headless component to maximize reuse"
+  },
+  raffleBackoffice: {
+    title: "Lightweight CMS for Raffle Backoffice",
+    titleFunc: "Designed and built a simple CMS for raffle operations to reduce repetitive manual workflows",
+    delivery: "Backoffice handled form editing, while preview rendering was separated via an embedded <object> page",
+    impact: "Split data sources (API for production, previewdata query for preview) to enable faster QA and operations"
+  },
+  couponWebview: {
+    title: "In-app WebView Development for My Coupon Page",
+    titleFunc: "Developed and operated a coupon WebView with web-bridge integration across iOS and Android",
+    bridge: "Used structured app-web event and state-passing contracts to support feature additions and maintenance",
+    ux: "Implemented context-aware UX such as deep-link entry scrolling to a target coupon and opening details in a BottomSheet"
+  },
+  bundlingProject: {
+    title: "Bundling Project (Accommodation + Vehicle Reservation)",
+    titleFunc: "Joined from the early planning phase and proposed an implementation strategy based on composing existing View components",
+    package: "Added an intermediate View Package to the internal monorepo to improve cross-screen reusability",
+    result: "Improved development speed and reusability through QA round 3; project was later dropped by internal prioritization"
   }
+
 };
 
 export const OYSTERABLE = {

--- a/src/languages/ko/Resume/experience.js
+++ b/src/languages/ko/Resume/experience.js
@@ -44,6 +44,33 @@ export const SOCAR = {
     testCode: "테스트 코드 및 문서화를 통해 재사용성과 안정성을 확보",
     using: "공통 패키지의 배포·테스트 자동화를 구축하여 유지보수 비용 감소",
   },
+  raffleBackoffice: {
+    title: "래플 서비스 백오피스용 경량 CMS 개발",
+    titleFunc:
+      "운영팀의 반복 업무를 줄이기 위한 래플 운영용 백오피스 CMS를 빠르게 설계·개발",
+    delivery:
+      "백오피스는 폼 편집을 담당하고, 프리뷰 페이지는 <object> 임베딩으로 분리 운영",
+    impact:
+      "실서비스는 API, 미리보기는 previewdata 쿼리 기반으로 분리해 빠른 검수/운영 흐름을 구축",
+  },
+  couponWebview: {
+    title: "내 쿠폰 페이지 인앱 웹뷰 개발",
+    titleFunc:
+      "웹브릿지 연동 및 iOS/Android 플랫폼 차이를 고려한 쿠폰 페이지 웹뷰를 개발·운영",
+    bridge:
+      "앱-웹 간 이벤트 정리된 상태 전달 로직 규격을 활용해 기능 추가/유지보수에 활용",
+    ux:
+      "외부 딥링크 진입 시 특정 쿠폰으로 스크롤하고 상세를 BottomSheet로 노출하는 등 진입 맥락 기반 UX를 구현",
+  },
+  bundlingProject: {
+    title: "번들링(숙소+차량 동시 예약) 프로젝트",
+    titleFunc:
+      "초기 기획 단계부터 참여해 기존 View 컴포넌트 조합 기반의 구현 전략을 제안",
+    package:
+      "내부 모노레포에 중간 View Package를 추가해 여러 화면에서 재사용 가능한 합성 레이어를 구축",
+    result:
+      "재사용성 및 개발 속도를 높였고, 3차 QA 단계까지 검증 후 사업 우선순위 변경으로 프로젝트가 중단",
+  },
 };
 
 export const OYSTERABLE = {

--- a/src/pages/Resume/constants/experience.js
+++ b/src/pages/Resume/constants/experience.js
@@ -29,7 +29,6 @@ export const EXPERIENCE = [
                 deployLink:
                   "https://tech.socarcorp.kr/fe/2026/02/24/socar-frame2-web-part2.html",
               },
-              ,
               SOCAR.designSystem.accessibility,
             ],
           },
@@ -59,6 +58,43 @@ export const EXPERIENCE = [
             actions: [
               SOCAR.commonPackages.testCode,
               SOCAR.commonPackages.using,
+            ],
+          },
+        ],
+      },
+
+      {
+        title: SOCAR.raffleBackoffice.title,
+        deployLink: "",
+        detailList: [
+          {
+            target: SOCAR.raffleBackoffice.titleFunc,
+            actions: [
+              SOCAR.raffleBackoffice.delivery,
+              SOCAR.raffleBackoffice.impact,
+            ],
+          },
+        ],
+      },
+      {
+        title: SOCAR.couponWebview.title,
+        deployLink: "",
+        detailList: [
+          {
+            target: SOCAR.couponWebview.titleFunc,
+            actions: [SOCAR.couponWebview.bridge, SOCAR.couponWebview.ux],
+          },
+        ],
+      },
+      {
+        title: SOCAR.bundlingProject.title,
+        deployLink: "",
+        detailList: [
+          {
+            target: SOCAR.bundlingProject.titleFunc,
+            actions: [
+              SOCAR.bundlingProject.package,
+              SOCAR.bundlingProject.result,
             ],
           },
         ],


### PR DESCRIPTION
### Motivation
- Expand the SOCAR work history in the resume to include recently delivered features and projects that weren't previously documented. 
- Provide both English and Korean localized descriptions for new items to keep language parity in the resume content. 
- Ensure the new items are rendered in the resume UI by adding them to the `EXPERIENCE` list.

### Description
- Added three new experience blocks to SOCAR in `src/languages/eng/Resume/experience.js`: `raffleBackoffice`, `couponWebview`, and `bundlingProject` with titles, functions, and impact/delivery notes. 
- Added corresponding Korean translations for the same three blocks in `src/languages/ko/Resume/experience.js`. 
- Wired the new SOCAR items into the rendered resume by inserting entries for `raffleBackoffice`, `couponWebview`, and `bundlingProject` in `src/pages/Resume/constants/experience.js` so they appear in the `EXPERIENCE` array. 
- Cleaned up a small formatting issue in the `EXPERIENCE` list to ensure the detail arrays are valid JavaScript.

### Testing
- Ran a local build with `yarn build` to verify the app compiles successfully; the build completed without errors. 
- Ran linting with `yarn lint` to confirm formatting and lint rules pass; linting succeeded. 
- No unit tests were modified by this change and existing test suites remain unchanged; CI is expected to run the project test matrix as usual.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b37fc370fc8320886a567772fb289d)