### PR TITLE
feat: navy theme refresh and home layout cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,9 @@
         "webpack": "^5.11.1",
         "webpack-cli": "^4.3.0",
         "webpack-dev-server": "^4.2.1"
+      },
+      "engines": {
+        "node": "24.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -12,6 +12,8 @@ class Header {
     this.$wrapper.innerHTML = /* html */ `
     <div class="header_profile_wrapper">
       <img src="/static/images/profile/selfie_japan.jpeg" alt="profile_image" />
+      <h2>Sanghun Lee</h2>
+      <p>Developer Blog</p>
       <ul>
       ${[]
         .map((el) => {

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -30,7 +30,7 @@ class Nav {
 
   render = () => {
     this.$wrapper.innerHTML = `
-      <h1>Sanghun Lee</h1>
+      <h1>sanghun.dev <span>devlog</span></h1>
       <ul class="nav_list">
         ${SHOW_ROUTE.map((el) => {
           return `

--- a/src/components/PostCard.js
+++ b/src/components/PostCard.js
@@ -21,7 +21,7 @@ export const PostCard = ({
         <div class="each_post_profile">
           <img src="../../static/images/profile/selfie_japan.jpeg" alt="profile_image" loading="lazy">
         <div class ="each_post_profile_detail">
-          <span>Cloud Lee</span>
+          <span>Sanghun Lee</span>
           <div>
             <div class="post_category_$wrapper">
               ${categories?.map((category) => `<span>${category}</span>`)}

--- a/src/index.html
+++ b/src/index.html
@@ -24,7 +24,7 @@
   <!-- basic meta tag -->
   <meta name="description" content="프론트엔드 개발자 이상훈 블로그" />
   <meta name="keywords" content="HTML, CSS, JavaScript, Front-end, 프론트엔드" />
-  <meta name="author" content="Cloud Lee" />
+  <meta name="author" content="Sanghun Lee" />
 
   <!-- open graph for share link -->
   <meta name="og:title" content="Vanilla javascript blog by Cloud Sanghun lee" />

--- a/src/pages/Home/constants/element.js
+++ b/src/pages/Home/constants/element.js
@@ -1,5 +1,4 @@
 export const $ELEMENT = {
   HOME_MAIN_CONTAINER: "home-main-container",
   LATEST_POST_CONTAINER: "latest-post-container",
-  RESUME_CONTAINERL: "resume-container",
 };

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -1,4 +1,3 @@
-import Contribution from './components/Contribution/index.js';
 import LatestPost from './components/LatestPost/index.js';
 import { $ELEMENT } from './constants/element.js';
 
@@ -16,7 +15,6 @@ class Home {
     return `
     <div>
       <section class="${$ELEMENT.LATEST_POST_CONTAINER}"></section>
-      <section class="${$ELEMENT.RESUME_CONTAINERL}"></section>
     </div>
     `;
   };
@@ -27,14 +25,9 @@ class Home {
     const postContainer = document.querySelector(
       `.${$ELEMENT.LATEST_POST_CONTAINER}`
     );
-    const resumeContainer = document.querySelector(
-      `.${$ELEMENT.RESUME_CONTAINERL}`
-    );
-
     new LatestPost({
       $target: postContainer,
     });
-    new Contribution({ $target: resumeContainer });
   };
 
   addListeners = () => {};

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -9,6 +9,7 @@
   padding: 24px;
   max-width: var(--basic-width);
   margin: 0px auto;
+  min-height: calc(100vh - 240px);
 }
 
 .post_container {
@@ -81,9 +82,14 @@ a {
 .each_post_container {
   width: 100%;
   margin-bottom: 50px;
-  padding-bottom: 50px;
+  padding-bottom: 22px;
   text-decoration-line: none;
   z-index: 2;
+  border: 1px solid #d8dfef;
+  border-radius: 16px;
+  background-color: #ffffff;
+  box-shadow: 0 8px 20px rgba(30, 43, 69, 0.08);
+  overflow: hidden;
 }
 
 .each_post_container .title_image {
@@ -118,12 +124,12 @@ a {
 
 .each_post_contents {
   padding: 12px 0px;
-  box-shadow: 0px 10px 10px rgba(0, 0, 0, 0.15);
 }
 
 .each_post_contents h1 {
   margin-bottom: 8px;
-  margin-left: 12px;
+  margin-left: 20px;
+  margin-right: 20px;
 }
 
 .each_post_contents h1 a {
@@ -137,11 +143,14 @@ a {
 
 .each_post_profile {
   display: flex;
-  margin-left: 12px;
+  margin-left: 20px;
 }
 
 .preview_content {
-  margin-left: 12px;
+  margin-left: 20px;
+  margin-right: 20px;
+  color: #4f5c78;
+  line-height: 1.7;
 }
 
 .each_post_profile img {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4,10 +4,10 @@
 :root {
   --basic-width: 1024px;
   --phone-width: 512px;
-  --basic-gray: #adbac7;
-  --strong-gray: #1e262f;
-  --basic-blue: #4a7fd5;
-  --strong-blue: #2a70db;
+  --basic-gray: #7e8aa3;
+  --strong-gray: #1e2b45;
+  --basic-blue: #2f4b86;
+  --strong-blue: #1c3362;
   --header-border-bottom: -webkit-linear-gradient(
     left,
     #fff 0,
@@ -33,6 +33,8 @@ body {
     "Noto Sans KR",
     "Segoe UI",
     sans-serif;
+  color: var(--strong-gray);
+  background-color: #f6f8fc;
 }
 
 button,
@@ -69,7 +71,10 @@ textarea {
   margin: 0 auto;
 }
 .header {
-  border-bottom: var(--header-nav-bottom);
+  border: 1px solid #dde3f0;
+  border-radius: 0 0 16px 16px;
+  background-color: #ffffff;
+  box-shadow: 0 10px 22px rgba(30, 43, 69, 0.08);
   padding: 0px 24px;
   transition: all 0.3s ease-in-out;
   max-height: 352px;
@@ -89,6 +94,7 @@ textarea {
   width: 100%;
   margin-bottom: 0.5px;
   background-color: white;
+  gap: 4px;
 }
 
 .header_profile_wrapper img {
@@ -102,6 +108,21 @@ textarea {
   border-radius: 65px;
   margin-top: 24px;
   margin-bottom: 8px;
+  border: 4px solid #e5eafa;
+  box-shadow: 0 8px 18px rgba(33, 61, 118, 0.18);
+}
+
+.header_profile h2 {
+  margin: 0;
+  color: var(--strong-gray);
+  font-size: 36px;
+}
+
+.header_profile p {
+  margin: 0;
+  color: var(--basic-gray);
+  font-size: 20px;
+  font-weight: 500;
 }
 
 .header_profile ul {
@@ -149,12 +170,13 @@ textarea {
 
 .nav_list li a {
   text-decoration: none;
-  color: black;
+  color: var(--strong-gray);
+  font-weight: 600;
 }
 
 .nav_list li a:hover {
   text-decoration: none;
-  color: var(--basic-gray);
+  color: var(--basic-blue);
 }
 
 .burger-button {
@@ -166,6 +188,10 @@ textarea {
     display: flex;
     justify-content: center;
     align-items: center;
+  }
+
+  .nav h1 {
+    font-size: 34px;
   }
 
   .nav_list {
@@ -194,7 +220,7 @@ textarea {
     position: fixed;
     left: 12px;
     top: 12px;
-    background-color: white;
+    background-color: #f8faff;
     border: none;
     z-index: 3;
     display: flex;
@@ -205,7 +231,7 @@ textarea {
   }
 
   .burger-button > div {
-    border-bottom: 2px solid #000;
+    border-bottom: 2px solid var(--strong-gray);
     width: 100%;
     margin: 2px 0;
     transition: all 0.15s ease-in-out;
@@ -219,7 +245,7 @@ textarea {
   position: fixed;
   left: 12px;
   top: 12px;
-  background-color: white;
+  background-color: #f8faff;
   border: none;
   z-index: 3;
   display: flex;
@@ -230,7 +256,7 @@ textarea {
 }
 
 .burger-button > div {
-  border-bottom: 2px solid #000;
+  border-bottom: 2px solid var(--strong-gray);
   width: 100%;
   margin: 2px 0;
   transition: all 0.15s ease-in-out;
@@ -270,8 +296,8 @@ textarea {
 .basic-button {
   font-size: 18px;
   height: 100%;
-  border: 1px solid white;
-  background-color: var(--basic-gray);
+  border: 1px solid var(--basic-blue);
+  background-color: var(--basic-blue);
   color: white;
   border-radius: 4px;
   text-align: center;
@@ -285,9 +311,9 @@ textarea {
 }
 
 .basic-button:hover {
-  border: 1px solid var(--basic-gray);
+  border: 1px solid var(--basic-blue);
   background-color: white;
-  color: var(--basic-gray);
+  color: var(--basic-blue);
   border-radius: 4px;
   text-align: center;
   vertical-align: middle;
@@ -324,6 +350,19 @@ textarea {
 }
 .contribution-wrapper {
   width: 100%;
+}
+
+.nav h1 {
+  margin: 0;
+  color: var(--strong-gray);
+  font-size: 50px;
+  letter-spacing: -0.5px;
+}
+
+.nav h1 span {
+  font-size: 18px;
+  color: var(--basic-gray);
+  font-weight: 500;
 }
 
 .github-chart {


### PR DESCRIPTION
### Motivation
- Refresh the blog visual identity to a navy-centered theme while keeping the existing minimalist feel. 
- Simplify the home layout to focus on latest posts and remove the GitHub contribution widget. 
- Unify author metadata and on-card author display to the site owner name. 

### Description
- Removed the GitHub contribution section from the home page and cleaned up related element constants by updating `src/pages/Home/index.js` and `src/pages/Home/constants/element.js`.
- Added profile title and subtitle to the header in `src/components/Header.js` and changed the navigation title to `sanghun.dev devlog` in `src/components/Nav.js`.
- Replaced author mentions from `Cloud Lee` to `Sanghun Lee` in `src/components/PostCard.js` and updated the HTML meta author in `src/index.html`.
- Reworked global tokens and styling to navy tones and adjusted UI styles for header, navigation, buttons and burger button in `src/styles/style.css` and applied card-like visuals (border, radius, shadow, spacing) to posts in `src/styles/post.css`.
- Minor metadata sync added to `package-lock.json` (`engines.node: 24.x`).

### Testing
- Ran `npm run lint` which completed with no errors and `5` CSS baseline warnings. 
- Ran `npm run build:deploy` which compiled successfully (webpack build succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc9c60b8c08320b2b27ebcd161f93e)